### PR TITLE
[MTG-341] iterate the tree as it's a tree and not a slice

### DIFF
--- a/programs/rewards/src/state/mining.rs
+++ b/programs/rewards/src/state/mining.rs
@@ -165,14 +165,7 @@ impl Mining {
         unclaimed_rewards: &mut u64,
         index_with_precision: &mut u128,
     ) -> ProgramResult {
-        let mut vault_index_for_date = 0;
-        for (index_date, index) in cumulative_index.iter() {
-            if index_date < &date {
-                vault_index_for_date = *index;
-            } else {
-                break;
-            }
-        }
+        let vault_index_for_date = Mining::vault_index_for_date(cumulative_index, date);
 
         let rewards = u64::try_from(
             vault_index_for_date
@@ -189,6 +182,26 @@ impl Mining {
         *index_with_precision = vault_index_for_date;
 
         Ok(())
+    }
+
+    fn vault_index_for_date(tree: &CumulativeIndex, value: u64) -> u128 {
+        let mut current_id = tree.root; // Start at the root node
+        let mut result = 0;
+
+        while current_id != 0 {
+            let node = tree.get_node(current_id); // Get the current node
+            if node.key < value {
+                // Update result to the current key if it's a valid candidate
+                result = node.value;
+                // Move to the right subtree to potentially find a larger valid key
+                current_id = tree.get_right(current_id);
+            } else {
+                // Move to the left subtree to find a smaller key
+                current_id = tree.get_left(current_id);
+            }
+        }
+
+        result
     }
 }
 


### PR DESCRIPTION
CU of one test before the change:

```
test distribute_rewards::happy_path_with_flex_continious_distribution_with_two_users ... ok
.....
[2024-08-05T16:04:06.351342000Z DEBUG solana_runtime::message_processor::stable_log] Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4645 of 180758 compute units
[2024-08-05T16:04:06.351370000Z DEBUG solana_runtime::message_processor::stable_log] Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success
[2024-08-05T16:04:06.351474000Z DEBUG solana_runtime::message_processor::stable_log] Program BF5PatmRTQDgEKoXR7iHRbkibEEi83nVM38cUKWzQcTR consumed 24341 of 200000 compute units
...
```
After:
```
test distribute_rewards::happy_path_with_flex_continious_distribution_with_two_users ... ok
...
[2024-08-05T16:02:51.415124000Z DEBUG solana_runtime::message_processor::stable_log] Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4645 of 190882 compute units
[2024-08-05T16:02:51.415154000Z DEBUG solana_runtime::message_processor::stable_log] Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success
[2024-08-05T16:02:51.415262000Z DEBUG solana_runtime::message_processor::stable_log] Program BF5PatmRTQDgEKoXR7iHRbkibEEi83nVM38cUKWzQcTR consumed 14217 of 200000 compute units
[2024-08-05T16:02:51.415283000Z DEBUG solana_runtime::message_processor::stable_log] Program return: BF5PatmRTQDgEKoXR7iHRbkibEEi83nVM38cUKWzQcTR ZAAAAAAAAAA=
[2024-08-05T16:02:51.415305000Z DEBUG solana_runtime::message_processor::stable_log] Program BF5PatmRTQDgEKoXR7iHRbkibEEi83nVM38cUKWzQcTR success
test distribute_rewards::happy_path_with_flex_continious_distribution ... ok

```
